### PR TITLE
Histories for relation methods

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ ruby "2.6.3"
 gem "activerecord", "~> 5.1"
 gem "activesupport"
 gem "rollbar"
+gem "activerecord-import"
 
 group :development, :test do
   gem "pg"
@@ -26,4 +27,5 @@ group :test do
   gem "guard"
   gem "guard-rspec"
   gem "database_cleaner"
+  gem "factory_bot_rails"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,8 @@ GEM
       activemodel (= 5.2.3)
       activesupport (= 5.2.3)
       arel (>= 9.0)
+    activerecord-import (1.0.2)
+      activerecord (>= 3.2)
     activesupport (5.2.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
@@ -54,6 +56,11 @@ GEM
     diff-lcs (1.3)
     docile (1.3.2)
     erubi (1.8.0)
+    factory_bot (5.1.1)
+      activesupport (>= 4.2.0)
+    factory_bot_rails (5.1.1)
+      factory_bot (~> 5.1.0)
+      railties (>= 4.2.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     ffi (1.11.1)
@@ -178,9 +185,11 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord (~> 5.1)
+  activerecord-import
   activesupport
   bundler (~> 1.0)
   database_cleaner
+  factory_bot_rails
   guard
   guard-rspec
   jeweler!

--- a/lib/historiographer.rb
+++ b/lib/historiographer.rb
@@ -249,5 +249,9 @@ module Historiographer
     def history_class
       "#{name}History".constantize
     end
+
+    def relation
+      super.tap { |r| r.extend Historiographer::Relation }
+    end
   end
 end

--- a/lib/historiographer/history.rb
+++ b/lib/historiographer/history.rb
@@ -66,11 +66,7 @@ module Historiographer
       # access to a current scope, returning
       # the most recent history.
       #
-      # Although we never want there to be more than 1 current history,
-      # in the off chance this invariant is broken, this method is
-      # guaranteed to only return an array containing the most recent history.
-      #
-      scope :current, -> { where(history_ended_at: nil).order(id: :desc).limit(1) }
+      scope :current, -> { where(history_ended_at: nil).order(id: :desc) }
 
       #
       # A History class will be linked to the user

--- a/lib/historiographer/relation.rb
+++ b/lib/historiographer/relation.rb
@@ -83,6 +83,10 @@ module Historiographer
       end
     end
 
+    def destroy_all_without_history
+      records.each(&:destroy_without_history).tap { reset }
+    end
+
     def destroy_all(history_user_id: nil)
       records.each { |r| r.destroy(history_user_id: history_user_id) }.tap { reset }
     end

--- a/lib/historiographer/relation.rb
+++ b/lib/historiographer/relation.rb
@@ -1,0 +1,90 @@
+module Historiographer
+  module Relation
+    extend ActiveSupport::Concern
+
+    def has_histories?
+      self.klass.respond_to?(:history_class)
+    end
+
+    def update_all_without_history(updates)
+      update_all(updates, false)
+    end
+
+    def update_all(updates, histories=true)
+      unless histories
+        super(updates)
+      else
+        updates.symbolize_keys!
+
+        ActiveRecord::Base.transaction do
+          super(updates.except(:history_user_id))
+          now = UTC.now
+          records = self.reload
+          history_class = records.klass.history_class
+
+          records.new.send(:history_user_absent_action) if updates[:history_user_id].nil?
+          history_user_id = updates[:history_user_id]
+
+          new_histories = records.map do |record|
+            attrs         = record.attributes.clone
+            foreign_key   = history_class.history_foreign_key
+      
+            now = UTC.now
+            attrs.merge!(foreign_key => attrs["id"], history_started_at: now, history_user_id: history_user_id)
+      
+            attrs = attrs.except("id")
+
+            record.histories.build(attrs)
+          end
+
+          current_histories = history_class.current.where("#{history_class.history_foreign_key} IN (?)", records.map(&:id))
+
+          current_histories.update_all(history_ended_at: now)
+
+          history_class.import new_histories
+        end
+      end
+    end
+
+    def delete_all_without_history
+      delete_all(nil, false)
+    end
+
+    def delete_all(options={}, histories=true)
+      unless histories
+        super()
+      else
+        ActiveRecord::Base.transaction do
+          records = self
+          history_class = records.first.class.history_class
+          history_user_id = options[:history_user_id]
+          records.first.send(:history_user_absent_action) if history_user_id.nil?
+          now = UTC.now
+
+          history_class.current.where("#{history_class.history_foreign_key} IN (?)", records.map(&:id)).update_all(history_ended_at: now)
+
+          if records.first.respond_to?(:paranoia_destroy)
+            new_histories = records.map do |record|
+              attrs         = record.attributes.clone
+              foreign_key   = history_class.history_foreign_key
+        
+              now = UTC.now
+              attrs.merge!(foreign_key => attrs["id"], history_started_at: now, history_user_id: history_user_id, deleted_at: now)
+        
+              attrs = attrs.except("id")
+
+              record.histories.build(attrs)
+            end
+            history_class.import new_histories
+          end
+
+          super()
+        end
+      end
+    end
+
+    def destroy_all(history_user_id: nil)
+      records.each { |r| r.destroy(history_user_id: history_user_id) }.tap { reset }
+    end
+  end
+end

--- a/spec/db/migrate/20191024203106_create_thing_without_history.rb
+++ b/spec/db/migrate/20191024203106_create_thing_without_history.rb
@@ -1,0 +1,7 @@
+class CreateThingWithoutHistory < ActiveRecord::Migration[5.2]
+  def change
+    create_table :thing_without_histories do |t|
+      t.string :name
+    end
+  end
+end

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_24_142352) do
+ActiveRecord::Schema.define(version: 2019_10_24_203106) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -135,6 +135,10 @@ ActiveRecord::Schema.define(version: 2019_10_24_142352) do
     t.string "key"
     t.string "value"
     t.index ["key", "value"], name: "idx_key_value"
+  end
+
+  create_table "thing_without_histories", force: :cascade do |t|
+    t.string "name"
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/factories/post.rb
+++ b/spec/factories/post.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :post do
+    sequence(:title) { |n| "Post #{n}"}
+    body { "The body of the post" }
+    author_id { 1 }
+  end
+end

--- a/spec/historiographer_spec.rb
+++ b/spec/historiographer_spec.rb
@@ -176,6 +176,8 @@ describe Historiographer do
 
           expect(ThingWithoutHistory.all.map(&:name)).to all(eq "Thing 3")
           expect(ThingWithoutHistory.all).to_not respond_to :has_histories?
+          expect(ThingWithoutHistory.all).to_not respond_to :update_all_without_history
+          expect(ThingWithoutHistory.all).to_not respond_to :delete_all_without_history
         end
         
         it "respects safety" do
@@ -259,6 +261,16 @@ describe Historiographer do
           expect(PostHistory.current.map(&:history_user_id)).to all(eq 1)
           expect(PostHistory.where(deleted_at: nil).where.not(history_ended_at: nil).count).to eq 3
           expect(PostHistory.where(history_ended_at: nil).count).to eq 3
+          expect(Post.count).to eq 0
+          Timecop.return
+        end
+
+        it "destroys without histories" do
+          Timecop.freeze
+          posts = FactoryBot.create_list(:post, 3, history_user_id: 1)
+          Post.all.destroy_all_without_history
+          expect(PostHistory.count).to eq 3
+          expect(PostHistory.current.count).to eq 3
           expect(Post.count).to eq 0
           Timecop.return
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,10 @@ ENV["HISTORIOGRAPHY_ENV"] = "test"
 
 require_relative "../init.rb"
 require "ostruct"
+require "factory_bot"
+
+FactoryBot.definition_file_paths = %w{./factories ./spec/factories}
+FactoryBot.find_definitions
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
@@ -36,5 +40,13 @@ RSpec.configure do |config|
     DatabaseCleaner.cleaning do
       example.run
     end
+  end
+
+  config.before(:each, :logsql) do
+    ActiveRecord::Base.logger = Logger.new(STDOUT)
+  end
+
+  config.after(:each, :logsql) do
+    ActiveRecord::Base.logger = nil
   end
 end


### PR DESCRIPTION
Allows recording of histories on `update_all`, `delete_all`, and `destroy_all`