### PR TITLE
Oracle database support added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ pkg
 spec/examples.txt
 tmp/
 *.log
+.idea/

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ end
 You should create a model named _posts_histories_:
 
 ```ruby
-require "historiographer/postgres_migration"
+require "historiographer/postgres_migration" # or require "historiographer/mysql_migration" for MySql or Oracle databases 
 class CreatePostHistories < ActiveRecord::Migration
   def change
     create_table :post_histories do |t|

--- a/lib/historiographer/mysql_migration.rb
+++ b/lib/historiographer/mysql_migration.rb
@@ -1,6 +1,6 @@
 require_relative "history_migration_mysql"
 
-if defined?(ActiveRecord::ConnectionAdapters::Mysql2Adapter)
+if defined?(ActiveRecord::ConnectionAdapters::Mysql2Adapter) || defined?(ActiveRecord::ConnectionAdapters::OracleEnhanced)
   class ActiveRecord::ConnectionAdapters::TableDefinition
     include Historiographer::HistoryMigrationMysql
   end


### PR DESCRIPTION
Oracle support added. Renamed migration_mysql to migration_fallback, because code is also used for Oracle.